### PR TITLE
fix: Update ul children to li tags and add fade transition

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,9 +51,6 @@
         href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap"
         rel="stylesheet"
     /></noscript>
-    <noscript
-      ><link rel="preload" href="/src/assets/images/fingertips.webp" as="image"
-    /></noscript>
 
     <title>Ghian Carlos Tan</title>
 

--- a/src/components/common/local-image-loader.tsx
+++ b/src/components/common/local-image-loader.tsx
@@ -39,7 +39,7 @@ const LocalImageLoader = ({
       <img
         src={src}
         alt={alt}
-        loading={loadLazy ? "lazy" : undefined}
+        loading={loadLazy ? "lazy" : "eager"}
         width={dimensions.width}
         height={dimensions.height}
         onLoad={(e: SyntheticEvent<HTMLImageElement>) => {
@@ -48,7 +48,7 @@ const LocalImageLoader = ({
           setDimensions({ width: naturalWidth, height: naturalHeight });
         }}
         className={cn(
-          "transition-opacity duration-500 ease-in-out w-full h-full",
+          "transition-opacity duration-500 ease-in-out",
           loaded ? "opacity-100" : "opacity-0",
           className
         )}

--- a/src/components/footer/socials.tsx
+++ b/src/components/footer/socials.tsx
@@ -8,15 +8,18 @@ const Socials = () => {
     <ul className="flex items-start gap-x-2">
       {SOCIALS.filter((s) => s.label !== "LinkedIn").map((s) => (
         <Hint key={`footer-${s.label}`} asChild label={s.label} side="top">
-          <Link
-            to={s.href}
-            target="_blank"
-            className="hover:drop-shadow-primary-glow transition-all"
+          <li
+            className="rounded-full border border-primary/50 hover:border-primary bg-primary/20 
+            hover:bg-primary/50 hover:drop-shadow-primary-glow transition-all size-8 lg:size-10"
           >
-            <li className="rounded-full border border-primary/50 hover:border-primary bg-primary/20 hover:bg-primary/50 p-1.5 lg:p-2.5">
-              <s.icon className="w-4 h-4 pointer-events-none" />
-            </li>
-          </Link>
+            <Link
+              to={s.href}
+              target="_blank"
+              className="w-full h-full flex-center"
+            >
+              <s.icon className="w-2.5 h-2.5 lg:w-4 lg:h-4 pointer-events-none" />
+            </Link>
+          </li>
         </Hint>
       ))}
     </ul>

--- a/src/components/header/logo.tsx
+++ b/src/components/header/logo.tsx
@@ -36,7 +36,7 @@ const Logo = () => {
         alt="Logo"
         width={lg ? 89.9 : 74.91}
         height={lg ? 21.2 : 17.66}
-        className="w-[74.91px] lg:w-[89.9px] h-[17.66px] lg:h-[21.2px] object-contain"
+        className="object-contain"
         loading="eager"
       />
     </Link>

--- a/src/pages/root/_components/contact/other-contacts.tsx
+++ b/src/pages/root/_components/contact/other-contacts.tsx
@@ -20,15 +20,19 @@ const OtherContacts = () => {
 
         return (
           <Hint key={c.href} asChild label={c.label} side="top">
-            <Link
-              to={c.href}
-              target="_blank"
-              className="rounded-full border border-muted-foreground p-2.5
-                hover:scale-105 hover:-translate-y-2 transition-all
-                ease-in-out cursor-pointer hover:bg-muted-foreground group hover:drop-shadow-foreground-glow"
+            <li
+              className="rounded-full border border-muted-foreground hover:scale-105 
+                hover:-translate-y-2 transition-all ease-in-out cursor-pointer size-10
+                hover:bg-muted-foreground group hover:drop-shadow-foreground-glow"
             >
-              <Icon className="w-4 h-4 ease-in-out group-hover:text-background pointer-events-none" />
-            </Link>
+              <Link
+                to={c.href}
+                target="_blank"
+                className="w-full h-full flex-center"
+              >
+                <Icon className="w-4 h-4 ease-in-out group-hover:text-background" />
+              </Link>
+            </li>
           </Hint>
         );
       })}

--- a/src/pages/root/_components/hero/index.tsx
+++ b/src/pages/root/_components/hero/index.tsx
@@ -54,7 +54,7 @@ const Hero = () => {
               alt="Wave"
               width={lg ? 30.16 : 20.11} // 181 original width
               height={lg ? 32.16 : 21.44} // 193 original height
-              className="w-[20.11px] lg:w-[30.16px] h-[21.44px] lg:h-[32.16px] relative -top-0.5 lg:-top-2"
+              className="relative -top-0.5 lg:-top-2"
             />
           </div>
           <h1 className="text-2xl lg:text-4xl font-bold flex items-center flex-col lg:flex-row">

--- a/src/pages/root/_components/hero/social-buttons.tsx
+++ b/src/pages/root/_components/hero/social-buttons.tsx
@@ -21,15 +21,19 @@ const SocialButtons = ({ isMounted }: SocialButtonsProps) => {
 
         return (
           <Hint key={s.href} asChild label={s.label} side="top">
-            <Link
-              to={s.href}
-              target="_blank"
-              className="rounded-full border border-muted-foreground p-2.5
-              hover:scale-105 hover:-translate-y-2 transition-all
-              ease-in-out cursor-pointer hover:bg-muted-foreground group hover:drop-shadow-foreground-glow"
+            <li
+              className="rounded-full border border-muted-foreground hover:scale-105 
+                hover:-translate-y-2 transition-all ease-in-out cursor-pointer size-10
+                hover:bg-muted-foreground group hover:drop-shadow-foreground-glow"
             >
-              <Icon className="w-4 h-4 transition-colors ease-in-out group-hover:text-background pointer-events-none" />
-            </Link>
+              <Link
+                to={s.href}
+                target="_blank"
+                className="w-full h-full flex-center"
+              >
+                <Icon className="w-4 h-4 ease-in-out group-hover:text-background" />
+              </Link>
+            </li>
           </Hint>
         );
       })}

--- a/src/pages/root/_components/projects/index.tsx
+++ b/src/pages/root/_components/projects/index.tsx
@@ -36,7 +36,11 @@ const Projects = () => {
         style={{
           gridAutoRows: "1fr",
         }}
-        className="w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 mt-8 gap-4"
+        className={cn(
+          `w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 mt-8 gap-4
+          transition-opacity duration-500 ease-in-out`,
+          isVisible ? "opacity-100" : "opacity-0"
+        )}
       >
         {isVisible ? (
           <>


### PR DESCRIPTION
- Changed `ul` tag children to use `li` tags directly instead of `Link` components.
- Made adjustments to the images for improved display.
- Added a fade transition effect for the projects section.