### PR TITLE
fix: resolve deploy workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,6 +36,9 @@ jobs:
       - name: Run Build
         run: npm run build
 
+      - name: Check `dist` folder
+        run: ls -alh dist
+
       - name: Upload Build Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  deploy:
     name: Deploy Application
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
- Change job name from `build:` to `deploy:` in the deployment workflow for clarity
- Add step in the build workflow to check the generated `dist` folder
- Ensure that the `dist` folder is properly generated before deployment