### PR TITLE
chore: increase Dependabot open pull request limit to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    open-pull-requests-limit: 10
     reviewers:
       - Fingertips18
 
@@ -19,5 +20,6 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    open-pull-requests-limit: 10
     reviewers:
       - Fingertips18


### PR DESCRIPTION
- Updated `.github/dependabot.yml` to set `open-pull-requests-limit` to 10.
- Allows Dependabot to submit more concurrent PRs for dependency updates.