### PR TITLE
chore(dependabot): remove reviewers field and add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://help.github.com/articles/about-codeowners/
+
+- @Fingertips18

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
       prefix: "chore"
       include: "scope"
     open-pull-requests-limit: 10
-    reviewers:
-      - Fingertips18
 
   # Update GitHub Actions dependencies in the root directory
   - package-ecosystem: "github-actions"
@@ -21,5 +19,3 @@ updates:
       prefix: "chore"
       include: "scope"
     open-pull-requests-limit: 10
-    reviewers:
-      - Fingertips18


### PR DESCRIPTION
- Removed the deprecated reviewers field from `.github/dependabot.yml` as per GitHub’s deprecation notice.
- Added a `CODEOWNERS` file to specify the appropriate reviewers for Dependabot PRs.
- Ensures compatibility with upcoming changes and avoids warnings or failed automation workflows.