### PR TITLE
fix: show menus on large screens by adjusting flex utilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -605,9 +605,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3279,9 +3279,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5268,17 +5268,6 @@
         }
       }
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
-      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/vite": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.1.tgz",
@@ -5412,21 +5401,6 @@
       "dev": true,
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/yocto-queue": {

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -5,7 +5,7 @@ import { Logo } from "./logo";
 const Header = () => {
   return (
     <header className="h-14 w-full fixed z-50 top-0 flex-center bg-background/50 backdrop-blur-lg border-b px-4 md:px-8 lg:px-0 blur-performance">
-      <div className="flex-between h-full w-full max-w-screen-lg lg:px-4 xl:px-0">
+      <div className="flex-between size-full max-w-screen-lg lg:px-4 xl:px-0">
         <Logo />
         <Navbar />
         <div className="hidden lg:flex lg:items-end">

--- a/src/components/header/sheet-menu.tsx
+++ b/src/components/header/sheet-menu.tsx
@@ -38,10 +38,12 @@ const SheetMenu = ({ active }: SheetMenuProps) => {
   }, [width]);
 
   const onOpenChange = (open: boolean) => {
+    if (!lenis) return;
+
     if (open) {
-      lenis?.stop();
+      lenis.stop();
     } else {
-      lenis?.start();
+      lenis.start();
     }
   };
 

--- a/src/components/header/spread-menu.tsx
+++ b/src/components/header/spread-menu.tsx
@@ -3,6 +3,7 @@ import { useLenis } from "lenis/react";
 
 import { ROOTMENU } from "@/constants/collections";
 import { cn } from "@/lib/utils";
+import { AppRoutes } from "@/routes/app-routes";
 
 interface SpreadMenuProps {
   active: string;
@@ -14,17 +15,19 @@ const SpreadMenu = ({ active, isMounted }: SpreadMenuProps) => {
   const location = useLocation();
 
   const onClick = (id: string) => {
+    if (!lenis) return;
+
     const section = document.getElementById(id);
     if (section) {
-      lenis?.scrollTo(section);
+      lenis.scrollTo(section);
     }
   };
 
   return (
     <nav
       className={cn(
-        "hidden lg:flex-center px-4 flex-grow transition-opacity duration-500 ease-in-out",
-        location.pathname === "/"
+        "hidden lg:flex items-center justify-center px-4 flex-grow transition-opacity duration-500 ease-in-out",
+        location.pathname === AppRoutes.root
           ? "opacity-100"
           : "opacity-0 pointer-events-none"
       )}
@@ -35,9 +38,9 @@ const SpreadMenu = ({ active, isMounted }: SpreadMenuProps) => {
           isMounted ? "opacity-100" : "opacity-0"
         )}
       >
-        {ROOTMENU.map((m, i) => (
+        {ROOTMENU.map((m) => (
           <li
-            key={`${m.label}-${i}`}
+            key={m.label}
             className={cn(
               "capitalize text-sm font-semibold leading-none hover:scale-95 transition-all cursor-pointer hover:drop-shadow-primary-glow hover:text-accent",
               active === m.label && "text-accent"


### PR DESCRIPTION
Header navigation menus were not appearing due to custom `flex-center` utility not supporting responsive variants. Replaced with built-in Tailwind classes: `hidden lg:flex items-center justify-center` to ensure menus display correctly on large screens.