### PR TITLE
fix: scroll to top when clicking "View All" skills

### DIFF
--- a/src/pages/root/_components/skills/index.tsx
+++ b/src/pages/root/_components/skills/index.tsx
@@ -11,10 +11,18 @@ import { Frontend } from "./frontend";
 import { Backend } from "./backend";
 import { Others } from "./others";
 import { Tools } from "./tools";
+import { useLenis } from "lenis/react";
 
 const Skills = () => {
   const sectionRef = useRef<HTMLElement | null>(null);
   const { isVisible } = useObserver({ elementRef: sectionRef });
+  const lenis = useLenis();
+
+  const handleScroll = () => {
+    if (!lenis) return;
+
+    lenis.scrollTo(0);
+  };
 
   return (
     <section
@@ -38,6 +46,7 @@ const Skills = () => {
         </p>
         <Link
           to={AppRoutes.skills}
+          onClick={handleScroll}
           className="mt-2 text-sm hover:text-accent hover:drop-shadow-purple-glow underline-offset-4 hover:underline"
         >
           View All


### PR DESCRIPTION
- Added scroll-to-top behavior when the "View All" skills link is clicked
- Improves user experience by ensuring the skills section starts at the top of the viewport