### PR TITLE
chore: add eslint-plugin-simple-import-sort and fix lint issues

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import reactHooks from "eslint-plugin-react-hooks";
 import tseslint from "typescript-eslint";
 import globals from "globals";
 import js from "@eslint/js";
+import simpleImportSort from "eslint-plugin-simple-import-sort";
 
 export default tseslint.config(
   { ignores: ["dist", "./src/components/shadcn/*.{ts,tsx}"] },
@@ -16,6 +17,7 @@ export default tseslint.config(
     plugins: {
       "react-hooks": reactHooks,
       "react-refresh": reactRefresh,
+      "simple-import-sort": simpleImportSort,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
@@ -23,6 +25,15 @@ export default tseslint.config(
         "warn",
         { allowConstantExport: true },
       ],
+      "simple-import-sort/imports": "error",
+      "simple-import-sort/exports": "error",
+    },
+  },
+  {
+    files: ["./src/components/shadcn/**/*.{js,jsx,ts,tsx}"],
+    rules: {
+      "simple-import-sort/imports": "off",
+      "simple-import-sort/exports": "off",
     },
   }
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@radix-ui/react-tooltip": "^1.2.7",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "eslint-plugin-simple-import-sort": "^12.1.1",
         "lenis": "^1.3.8",
         "lucide-react": "^0.525.0",
         "react": "^18.3.1",
@@ -3249,6 +3250,15 @@
       "license": "MIT",
       "peerDependencies": {
         "eslint": ">=8.40"
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-tooltip": "^1.2.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "lenis": "^1.3.8",
     "lucide-react": "^0.525.0",
     "react": "^18.3.1",

--- a/src/components/common/skill-icon.tsx
+++ b/src/components/common/skill-icon.tsx
@@ -1,6 +1,6 @@
 import { IconType as IconsPackType } from "@icons-pack/react-simple-icons";
-import { IconType as ReactIconsType } from "react-icons/lib";
 import { useState } from "react";
+import { IconType as ReactIconsType } from "react-icons/lib";
 
 import { cn } from "@/lib/utils";
 

--- a/src/components/footer/socials.tsx
+++ b/src/components/footer/socials.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 
-import { SOCIALS } from "@/constants/collections";
 import { Hint } from "@/components/common/hint";
+import { SOCIALS } from "@/constants/collections";
 
 const Socials = () => {
   return (

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -1,6 +1,6 @@
+import { Logo } from "./logo";
 import { ModeToggle } from "./mode-toggle";
 import { Navbar } from "./navbar";
-import { Logo } from "./logo";
 
 const Header = () => {
   return (

--- a/src/components/header/logo.tsx
+++ b/src/components/header/logo.tsx
@@ -1,11 +1,11 @@
-import { Link } from "react-router-dom";
 import { useLenis } from "lenis/react";
+import { Link } from "react-router-dom";
 
-import { DARKLOGO, LIGHTLOGO } from "@/constants/assets";
 import { Skeleton } from "@/components/shadcn/skeleton";
-import { Theme, useTheme } from "@/lib/hooks/useTheme";
+import { DARKLOGO, LIGHTLOGO } from "@/constants/assets";
 import { useMounted } from "@/lib/hooks/useMounted";
 import { useResize } from "@/lib/hooks/useResize";
+import { Theme, useTheme } from "@/lib/hooks/useTheme";
 import { AppRoutes } from "@/routes/app-routes";
 
 const Logo = () => {

--- a/src/components/header/mode-toggle.tsx
+++ b/src/components/header/mode-toggle.tsx
@@ -1,5 +1,7 @@
 import { Moon, Sun } from "lucide-react";
 
+import { Hint } from "@/components/common/hint";
+import { Button } from "@/components/shadcn/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -7,10 +9,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/shadcn/dropdown-menu";
 import { Skeleton } from "@/components/shadcn/skeleton";
-import { Button } from "@/components/shadcn/button";
 import { useMounted } from "@/lib/hooks/useMounted";
 import { useTheme } from "@/lib/hooks/useTheme";
-import { Hint } from "@/components/common/hint";
 
 const ModeToggle = () => {
   const { setTheme } = useTheme();

--- a/src/components/header/navbar.tsx
+++ b/src/components/header/navbar.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useMemo } from "react";
 
-import { useRootSectionStore } from "@/lib/stores/useRootSectionStore";
+import { QUERYELEMENT } from "@/constants/enums";
 import { useElementsByQuery } from "@/lib/hooks/useElementsByQuery";
 import { useMounted } from "@/lib/hooks/useMounted";
-import { QUERYELEMENT } from "@/constants/enums";
+import { useRootSectionStore } from "@/lib/stores/useRootSectionStore";
 
-import { SpreadMenu } from "./spread-menu";
 import { SheetMenu } from "./sheet-menu";
+import { SpreadMenu } from "./spread-menu";
 
 const Navbar = () => {
   const { active, onActive } = useRootSectionStore((state) => state);

--- a/src/components/header/sheet-menu.tsx
+++ b/src/components/header/sheet-menu.tsx
@@ -1,8 +1,10 @@
-import { Link, useLocation } from "react-router-dom";
+import { useLenis } from "lenis/react";
 import { LucideMenu, MoveLeft } from "lucide-react";
 import { useEffect, useState } from "react";
-import { useLenis } from "lenis/react";
+import { Link, useLocation } from "react-router-dom";
 
+import { Hint } from "@/components/common/hint";
+import { Button } from "@/components/shadcn/button";
 import {
   Sheet,
   SheetContent,
@@ -12,12 +14,10 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/shadcn/sheet";
-import { Button } from "@/components/shadcn/button";
 import { ROOTMENU } from "@/constants/collections";
 import { useResize } from "@/lib/hooks/useResize";
-import { AppRoutes } from "@/routes/app-routes";
-import { Hint } from "@/components/common/hint";
 import { cn } from "@/lib/utils";
+import { AppRoutes } from "@/routes/app-routes";
 
 import { ModeToggle } from "./mode-toggle";
 

--- a/src/components/header/spread-menu.tsx
+++ b/src/components/header/spread-menu.tsx
@@ -1,5 +1,5 @@
-import { useLocation } from "react-router-dom";
 import { useLenis } from "lenis/react";
+import { useLocation } from "react-router-dom";
 
 import { ROOTMENU } from "@/constants/collections";
 import { cn } from "@/lib/utils";

--- a/src/constants/assets.ts
+++ b/src/constants/assets.ts
@@ -1,21 +1,20 @@
-import lightLogo from "@/assets/images/light-logo.webp";
-import darkLogo from "@/assets/images/dark-logo.webp";
-import me from "@/assets/images/me.webp";
-import fingertips from "@/assets/images/fingertips.webp";
-import gotworkDigital from "@/assets/images/gotwork-digital.webp";
-import convocade from "@/assets/images/convocade.webp";
-import graduateSchool from "@/assets/images/graduate-school.webp";
+import wave from "@/assets/gifs/wave.gif";
 import aquilarie from "@/assets/images/aquilarie.webp";
+import cmes from "@/assets/images/cmes-seal.webp";
+import convocade from "@/assets/images/convocade.webp";
+import darkLogo from "@/assets/images/dark-logo.webp";
+import fingertips from "@/assets/images/fingertips.webp";
+import flixSagePreview from "@/assets/images/flixsage-preview.webp";
+import gotworkDigital from "@/assets/images/gotwork-digital.webp";
+import graduateSchool from "@/assets/images/graduate-school.webp";
+import ktmsces from "@/assets/images/ktmsces-seal.webp";
+import leafonicPreview from "@/assets/images/leafonic-preview.webp";
+import lightLogo from "@/assets/images/light-logo.webp";
+import me from "@/assets/images/me.webp";
+import mnhs from "@/assets/images/mnhs-seal.webp";
 import mycaa from "@/assets/images/mycaa.webp";
 import tritokPreview from "@/assets/images/tritok-preview.webp";
-import leafonicPreview from "@/assets/images/leafonic-preview.webp";
-import flixSagePreview from "@/assets/images/flixsage-preview.webp";
 import usm from "@/assets/images/usm-seal.webp";
-import mnhs from "@/assets/images/mnhs-seal.webp";
-import ktmsces from "@/assets/images/ktmsces-seal.webp";
-import cmes from "@/assets/images/cmes-seal.webp";
-
-import wave from "@/assets/gifs/wave.gif";
 
 export const LIGHTLOGO = lightLogo;
 export const DARKLOGO = darkLogo;

--- a/src/constants/collections.ts
+++ b/src/constants/collections.ts
@@ -3,7 +3,6 @@ import {
   SiGithub,
   SiStackoverflow,
 } from "@icons-pack/react-simple-icons";
-
 import { SiLinkedin } from "react-icons/si";
 
 import { ROOTSECTION } from "./enums";

--- a/src/constants/contact.ts
+++ b/src/constants/contact.ts
@@ -1,5 +1,4 @@
-import { SiGmail, SiCalendly } from "@icons-pack/react-simple-icons";
-
+import { SiCalendly, SiGmail } from "@icons-pack/react-simple-icons";
 import { SiLinkedin } from "react-icons/si";
 
 export const CONTACTS = [

--- a/src/constants/projects.ts
+++ b/src/constants/projects.ts
@@ -1,10 +1,10 @@
+import { FLIXSAGEPREVIEW, LEAFONICPREVIEW, TRITOKPREVIEW } from "./assets";
+import { PROJECTTYPE } from "./enums";
 import {
   FLIXSAGEPREVIEW_HASH,
   LEAFONICPREVIEW_HASH,
   TRIKTOOKPREVIEW_HASH,
 } from "./hashes";
-import { FLIXSAGEPREVIEW, LEAFONICPREVIEW, TRITOKPREVIEW } from "./assets";
-import { PROJECTTYPE } from "./enums";
 
 export const FORMLINK = "https://forms.gle/PFHoohMazvKMeKCh7";
 

--- a/src/constants/skills.ts
+++ b/src/constants/skills.ts
@@ -98,7 +98,6 @@ import {
   SiZod,
   SiZodHex,
 } from "@icons-pack/react-simple-icons";
-
 import { SiAdobephotoshop } from "react-icons/si";
 
 export const FRONTEND = [

--- a/src/lib/stores/useRootSectionStore.tsx
+++ b/src/lib/stores/useRootSectionStore.tsx
@@ -1,5 +1,5 @@
-import { createJSONStorage, persist } from "zustand/middleware";
 import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
 
 import { ROOTSECTION } from "@/constants/enums";
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,12 @@
-import { RouterProvider } from "react-router-dom";
-import ReactDOM from "react-dom/client";
-import React from "react";
-
-import { ThemeProvider } from "./providers/theme-provider";
-import LenisProvider from "./providers/lenis-provider";
-import { router } from "./routes/router";
 import "./index.css";
+
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { RouterProvider } from "react-router-dom";
+
+import LenisProvider from "./providers/lenis-provider";
+import { ThemeProvider } from "./providers/theme-provider";
+import { router } from "./routes/router";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/src/pages/root/_components/contact/contact-form.tsx
+++ b/src/pages/root/_components/contact/contact-form.tsx
@@ -1,8 +1,8 @@
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm } from "react-hook-form";
 import emailjs from "@emailjs/browser";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader2 } from "lucide-react";
 import { useState } from "react";
+import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 
@@ -14,8 +14,8 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/shadcn/form";
-import { Textarea } from "@/components/shadcn/textarea";
 import { Input } from "@/components/shadcn/input";
+import { Textarea } from "@/components/shadcn/textarea";
 
 const formSchema = z.object({
   email: z

--- a/src/pages/root/_components/contact/index.tsx
+++ b/src/pages/root/_components/contact/index.tsx
@@ -1,12 +1,12 @@
 import { useRef } from "react";
 
-import { QUERYELEMENT, ROOTSECTION } from "@/constants/enums";
 import { Separator } from "@/components/shadcn/separator";
+import { QUERYELEMENT, ROOTSECTION } from "@/constants/enums";
 import { useObserver } from "@/lib/hooks/useObserver";
 import { cn } from "@/lib/utils";
 
-import { OtherContacts } from "./other-contacts";
 import { ContactForm } from "./contact-form";
+import { OtherContacts } from "./other-contacts";
 
 const Contact = () => {
   const sectionRef = useRef<HTMLElement | null>(null);

--- a/src/pages/root/_components/contact/other-contacts.tsx
+++ b/src/pages/root/_components/contact/other-contacts.tsx
@@ -1,8 +1,8 @@
 import { Link } from "react-router-dom";
 
-import { useMounted } from "@/lib/hooks/useMounted";
 import { Hint } from "@/components/common/hint";
 import { CONTACTS } from "@/constants/contact";
+import { useMounted } from "@/lib/hooks/useMounted";
 import { cn } from "@/lib/utils";
 
 const OtherContacts = () => {

--- a/src/pages/root/_components/education/education-item.tsx
+++ b/src/pages/root/_components/education/education-item.tsx
@@ -1,9 +1,9 @@
-import { VerticalTimelineElement } from "react-vertical-timeline-component";
 import { SiYoutube, SiYoutubeHex } from "@icons-pack/react-simple-icons";
 import { Link } from "react-router-dom";
+import { VerticalTimelineElement } from "react-vertical-timeline-component";
 
-import { Badge } from "@/components/shadcn/badge";
 import { Image } from "@/components/common/image";
+import { Badge } from "@/components/shadcn/badge";
 
 interface EducationItemProps {
   source: string;

--- a/src/pages/root/_components/education/index.tsx
+++ b/src/pages/root/_components/education/index.tsx
@@ -1,10 +1,10 @@
-import { VerticalTimeline } from "react-vertical-timeline-component";
 import { GraduationCap } from "lucide-react";
 import { useRef } from "react";
+import { VerticalTimeline } from "react-vertical-timeline-component";
 
+import { EDUCATIONS } from "@/constants/education";
 import { QUERYELEMENT, ROOTSECTION } from "@/constants/enums";
 import { useObserver } from "@/lib/hooks/useObserver";
-import { EDUCATIONS } from "@/constants/education";
 import { cn } from "@/lib/utils";
 
 import EducationItem from "./education-item";

--- a/src/pages/root/_components/experience/index.tsx
+++ b/src/pages/root/_components/experience/index.tsx
@@ -1,11 +1,12 @@
-import { VerticalTimeline } from "react-vertical-timeline-component";
 import "react-vertical-timeline-component/style.min.css";
+
 import { BriefcaseBusiness } from "lucide-react";
 import { useRef } from "react";
+import { VerticalTimeline } from "react-vertical-timeline-component";
 
 import { QUERYELEMENT, ROOTSECTION } from "@/constants/enums";
-import { useObserver } from "@/lib/hooks/useObserver";
 import { EXPERIENCES } from "@/constants/experiences";
+import { useObserver } from "@/lib/hooks/useObserver";
 import { cn } from "@/lib/utils";
 
 import { TimelineItem } from "./timeline-item";

--- a/src/pages/root/_components/experience/timeline-item.tsx
+++ b/src/pages/root/_components/experience/timeline-item.tsx
@@ -1,9 +1,10 @@
-import { VerticalTimelineElement } from "react-vertical-timeline-component";
 import "react-vertical-timeline-component/style.min.css";
-import { Link } from "react-router-dom";
 
-import { Badge } from "@/components/shadcn/badge";
+import { Link } from "react-router-dom";
+import { VerticalTimelineElement } from "react-vertical-timeline-component";
+
 import { Image } from "@/components/common/image";
+import { Badge } from "@/components/shadcn/badge";
 
 interface TimelineItemProps {
   image: string;

--- a/src/pages/root/_components/hero/index.tsx
+++ b/src/pages/root/_components/hero/index.tsx
@@ -1,18 +1,18 @@
 import { useRef } from "react";
 
-import { QUERYELEMENT, ROOTSECTION } from "@/constants/enums";
-import { useObserver } from "@/lib/hooks/useObserver";
-import { useMounted } from "@/lib/hooks/useMounted";
-import { useResize } from "@/lib/hooks/useResize";
-import { BUILDS } from "@/constants/collections";
 import { WAVE } from "@/constants/assets";
+import { BUILDS } from "@/constants/collections";
+import { QUERYELEMENT, ROOTSECTION } from "@/constants/enums";
+import { useMounted } from "@/lib/hooks/useMounted";
+import { useObserver } from "@/lib/hooks/useObserver";
+import { useResize } from "@/lib/hooks/useResize";
 import { cn } from "@/lib/utils";
 
+import { Introduction } from "./introduction";
 import { ProfilePicture } from "./profile-picture";
 import { ResumeButton } from "./resume-button";
-import { Introduction } from "./introduction";
-import { TypingTexts } from "./typing-texts";
 import SocialButtons from "./social-buttons";
+import { TypingTexts } from "./typing-texts";
 
 const Hero = () => {
   const sectionRef = useRef<HTMLElement | null>(null);

--- a/src/pages/root/_components/hero/profile-picture.tsx
+++ b/src/pages/root/_components/hero/profile-picture.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 
 import { LocalImageLoader } from "@/components/common/local-image-loader";
-import { FINGERTIPS_HASH, ME_HASH } from "@/constants/hashes";
 import { FINGERTIPS, ME } from "@/constants/assets";
+import { FINGERTIPS_HASH, ME_HASH } from "@/constants/hashes";
 import { cn } from "@/lib/utils";
 
 import { Background } from "./background";

--- a/src/pages/root/_components/hero/social-buttons.tsx
+++ b/src/pages/root/_components/hero/social-buttons.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 
-import { SOCIALS } from "@/constants/collections";
 import { Hint } from "@/components/common/hint";
+import { SOCIALS } from "@/constants/collections";
 import { cn } from "@/lib/utils";
 
 interface SocialButtonsProps {

--- a/src/pages/root/_components/projects/app-request-button.tsx
+++ b/src/pages/root/_components/projects/app-request-button.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 
+import { Button } from "@/components/shadcn/button";
 import {
   Dialog,
   DialogContent,
@@ -9,7 +10,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/shadcn/dialog";
-import { Button } from "@/components/shadcn/button";
 import { FORMLINK } from "@/constants/projects";
 
 const AppRequestButton = () => {

--- a/src/pages/root/_components/projects/index.tsx
+++ b/src/pages/root/_components/projects/index.tsx
@@ -2,8 +2,8 @@ import { Terminal } from "lucide-react";
 import { useRef } from "react";
 
 import { QUERYELEMENT, ROOTSECTION } from "@/constants/enums";
-import { useObserver } from "@/lib/hooks/useObserver";
 import { PROJECTS } from "@/constants/projects";
+import { useObserver } from "@/lib/hooks/useObserver";
 import { cn } from "@/lib/utils";
 
 import { ProjectItem, ProjectItemSkeleton } from "./project-item";

--- a/src/pages/root/_components/projects/project-item.tsx
+++ b/src/pages/root/_components/projects/project-item.tsx
@@ -1,7 +1,8 @@
-import { Link } from "react-router-dom";
 import { useLenis } from "lenis/react";
 import { useState } from "react";
+import { Link } from "react-router-dom";
 
+import { LocalImageLoader } from "@/components/common/local-image-loader";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -13,16 +14,15 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/shadcn/alert-dialog";
-import { LocalImageLoader } from "@/components/common/local-image-loader";
-import { Button } from "@/components/shadcn/button";
 import { Badge } from "@/components/shadcn/badge";
+import { Button } from "@/components/shadcn/button";
+import { Skeleton } from "@/components/shadcn/skeleton";
 import { PROJECTTYPE } from "@/constants/enums";
 import { FORMLINK } from "@/constants/projects";
 import { cn } from "@/lib/utils";
 
 import { AppRequestButton } from "./app-request-button";
 import { ProjectPreview } from "./project-preview";
-import { Skeleton } from "@/components/shadcn/skeleton";
 
 interface ProjectItemProps {
   preview: string;

--- a/src/pages/root/_components/skills/backend.tsx
+++ b/src/pages/root/_components/skills/backend.tsx
@@ -1,8 +1,7 @@
-import { useVisibility } from "@/lib/hooks/useVisibility";
+import { SkillIcon } from "@/components/common/skill-icon";
 import { BACKEND } from "@/constants/skills";
+import { useVisibility } from "@/lib/hooks/useVisibility";
 import { cn } from "@/lib/utils";
-
-import { SkillIcon } from "../../../../components/common/skill-icon";
 
 const Backend = () => {
   const { isVisible } = useVisibility();

--- a/src/pages/root/_components/skills/frontend.tsx
+++ b/src/pages/root/_components/skills/frontend.tsx
@@ -1,8 +1,7 @@
-import { useVisibility } from "@/lib/hooks/useVisibility";
+import { SkillIcon } from "@/components/common/skill-icon";
 import { FRONTEND } from "@/constants/skills";
+import { useVisibility } from "@/lib/hooks/useVisibility";
 import { cn } from "@/lib/utils";
-
-import { SkillIcon } from "../../../../components/common/skill-icon";
 
 const Frontend = () => {
   const { isVisible } = useVisibility();

--- a/src/pages/root/_components/skills/index.tsx
+++ b/src/pages/root/_components/skills/index.tsx
@@ -1,17 +1,17 @@
-import { Link } from "react-router-dom";
+import { useLenis } from "lenis/react";
 import { useRef } from "react";
+import { Link } from "react-router-dom";
 
 import { QUERYELEMENT, ROOTSECTION } from "@/constants/enums";
 import { useObserver } from "@/lib/hooks/useObserver";
-import { AppRoutes } from "@/routes/app-routes";
 import { cn } from "@/lib/utils";
+import { AppRoutes } from "@/routes/app-routes";
 
-import { GradientOverlay } from "./gradient-overlay";
-import { Frontend } from "./frontend";
 import { Backend } from "./backend";
+import { Frontend } from "./frontend";
+import { GradientOverlay } from "./gradient-overlay";
 import { Others } from "./others";
 import { Tools } from "./tools";
-import { useLenis } from "lenis/react";
 
 const Skills = () => {
   const sectionRef = useRef<HTMLElement | null>(null);

--- a/src/pages/root/_components/skills/others.tsx
+++ b/src/pages/root/_components/skills/others.tsx
@@ -1,8 +1,7 @@
-import { useVisibility } from "@/lib/hooks/useVisibility";
+import { SkillIcon } from "@/components/common/skill-icon";
 import { OTHERS } from "@/constants/skills";
+import { useVisibility } from "@/lib/hooks/useVisibility";
 import { cn } from "@/lib/utils";
-
-import { SkillIcon } from "../../../../components/common/skill-icon";
 
 const Others = () => {
   const { isVisible } = useVisibility();

--- a/src/pages/root/_components/skills/tools.tsx
+++ b/src/pages/root/_components/skills/tools.tsx
@@ -1,8 +1,7 @@
-import { useVisibility } from "@/lib/hooks/useVisibility";
-import { TOOLS } from "@/constants/skills";
-import { cn } from "@/lib/utils";
-
 import { SkillIcon } from "@/components/common/skill-icon";
+import { TOOLS } from "@/constants/skills";
+import { useVisibility } from "@/lib/hooks/useVisibility";
+import { cn } from "@/lib/utils";
 
 const Tools = () => {
   const { isVisible } = useVisibility();

--- a/src/pages/root/layout.tsx
+++ b/src/pages/root/layout.tsx
@@ -1,11 +1,11 @@
-import { Outlet } from "react-router-dom";
 import { useEffect } from "react";
 import ReactGA from "react-ga4";
+import { Outlet } from "react-router-dom";
 
+import { Footer } from "@/components/footer";
+import { Header } from "@/components/header";
 import ToasterProvider from "@/providers/toaster-provider";
 import { AppRoutes } from "@/routes/app-routes";
-import { Header } from "@/components/header";
-import { Footer } from "@/components/footer";
 
 const RootLayout = () => {
   useEffect(() => {

--- a/src/pages/root/page.tsx
+++ b/src/pages/root/page.tsx
@@ -1,9 +1,9 @@
-import { Experience } from "./_components/experience";
-import { Education } from "./_components/education";
-import { Projects } from "./_components/projects";
 import { Contact } from "./_components/contact";
-import { Skills } from "./_components/skills";
+import { Education } from "./_components/education";
+import { Experience } from "./_components/experience";
 import { Hero } from "./_components/hero";
+import { Projects } from "./_components/projects";
+import { Skills } from "./_components/skills";
 
 const RootPage = () => {
   return (

--- a/src/pages/skills/page.tsx
+++ b/src/pages/skills/page.tsx
@@ -2,8 +2,8 @@ import { MoveLeft } from "lucide-react";
 import { Link } from "react-router-dom";
 
 import { SkillIcon } from "@/components/common/skill-icon";
-import { AppRoutes } from "@/routes/app-routes";
 import { BACKEND, FRONTEND, OTHERS, TOOLS } from "@/constants/skills";
+import { AppRoutes } from "@/routes/app-routes";
 
 const SkillsPage = () => {
   return (

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -4,11 +4,11 @@ import {
   Route,
 } from "react-router-dom";
 
-import NotFoundPage from "@/pages/not-found/page";
-import { SkillsPage } from "@/pages/skills/page";
-import RootLayout from "@/pages/root/layout";
 import ErrorPage from "@/pages/error/page";
+import NotFoundPage from "@/pages/not-found/page";
+import RootLayout from "@/pages/root/layout";
 import RootPage from "@/pages/root/page";
+import { SkillsPage } from "@/pages/skills/page";
 
 import { AppRoutes } from "./app-routes";
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
-import react from "@vitejs/plugin-react-swc";
 import tailwindcss from "@tailwindcss/vite";
-import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react-swc";
 import path from "path";
+import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
- Installed `eslint-plugin-simple-import-sort` for consistent and automated import ordering
- Updated ESLint configuration to use the new plugin
- Ran `npm run lint` and resolved all complaints related to import sorting