### PR TITLE
ci: switch portfolio deploy to native GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,12 +1,20 @@
-name: Portfolio - Deploy
+name: Deploy Portfolio To GitHub Pages
 
 on:
   workflow_dispatch:
 
+permissions:
+  pages: write # Needed to deploy to Pages
+  id-token: write # Needed for OIDC auth
+  contents: read # Needed to read artifacts
+
 jobs:
   deploy:
-    name: Deploy Application
+    name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - name: Checkout Code
@@ -22,18 +30,11 @@ jobs:
           workflow_conclusion: success
           path: dist/
 
-      - name: Setup Git Identity
-        run: |
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          node-version: latest
-
-      - name: Install Dependencies
-        run: npm install gh-pages --save-dev
+          path: dist
 
       - name: Deploy to GitHub Pages
-        run: npx gh-pages -d dist --repo https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/Fingertips18/fingertips18.github.io.git
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Replaced `gh-pages` CLI deployment with native GitHub Pages Actions (`actions/upload-pages-artifact` and `actions/deploy-pages`).

- Set Pages source to GitHub Actions in repo settings
- Removed `gh-pages` `npm install` and branch push
- Added `upload-pages-artifact` step for dist folder
- Added `deploy-pages` step to trigger `pages-build-deployment` reliably
- Updated workflow permissions for Pages deploy

This ensures that the `pages-build-deployment` workflow runs on every manual deploy and removes inconsistencies from `gh-pages` CLI pushes.