### PR TITLE
feat: keep header navigation menus visible across routes and add hash-based navigation

### DIFF
--- a/src/components/header/spread-menu.tsx
+++ b/src/components/header/spread-menu.tsx
@@ -1,5 +1,5 @@
 import { useLenis } from 'lenis/react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { ROOTMENU } from '@/constants/collections';
 import { cn } from '@/lib/utils';
@@ -13,25 +13,24 @@ interface SpreadMenuProps {
 const SpreadMenu = ({ active, isMounted }: SpreadMenuProps) => {
   const lenis = useLenis();
   const location = useLocation();
+  const navigate = useNavigate();
 
-  const onClick = (id: string) => {
-    if (!lenis) return;
+  const onClick = (id: string, hash: string) => {
+    if (location.pathname === AppRoutes.root) {
+      if (!lenis) return;
 
-    const section = document.getElementById(id);
-    if (section) {
+      const section = document.getElementById(id);
+
+      if (!section) return;
+
       lenis.scrollTo(section);
+    } else {
+      navigate(AppRoutes.root + hash);
     }
   };
 
   return (
-    <nav
-      className={cn(
-        'hidden lg:flex items-center justify-center px-4 flex-grow transition-opacity duration-500 ease-in-out',
-        location.pathname === AppRoutes.root
-          ? 'opacity-100'
-          : 'opacity-0 pointer-events-none',
-      )}
-    >
+    <nav className='hidden lg:flex items-center justify-center px-4 flex-grow'>
       <ul
         className={cn(
           'flex-center gap-x-10 transition-opacity duration-1000 ease-in-out',
@@ -40,12 +39,12 @@ const SpreadMenu = ({ active, isMounted }: SpreadMenuProps) => {
       >
         {ROOTMENU.map((m) => (
           <li
-            key={m.label}
+            key={m.hash}
             className={cn(
               'capitalize text-sm font-semibold leading-none hover:scale-95 transition-all cursor-pointer hover:drop-shadow-primary-glow hover:text-accent',
               active === m.label && 'text-accent',
             )}
-            onClick={() => onClick(m.label)}
+            onClick={() => onClick(m.label, m.hash)}
           >
             {m.label}
           </li>

--- a/src/constants/collections.ts
+++ b/src/constants/collections.ts
@@ -10,27 +10,27 @@ import { ROOTSECTION } from './enums';
 export const ROOTMENU = [
   {
     label: ROOTSECTION.about,
-    id: `#${ROOTSECTION.about}`,
+    hash: `#${ROOTSECTION.about}`,
   },
   {
     label: ROOTSECTION.skills,
-    id: `#${ROOTSECTION.skills}`,
+    hash: `#${ROOTSECTION.skills}`,
   },
   {
     label: ROOTSECTION.experience,
-    id: `#${ROOTSECTION.experience}`,
+    hash: `#${ROOTSECTION.experience}`,
   },
   {
     label: ROOTSECTION.projects,
-    id: `#${ROOTSECTION.projects}`,
+    hash: `#${ROOTSECTION.projects}`,
   },
   {
     label: ROOTSECTION.education,
-    id: `#${ROOTSECTION.education}`,
+    hash: `#${ROOTSECTION.education}`,
   },
   {
     label: ROOTSECTION.contact,
-    id: `#${ROOTSECTION.contact}`,
+    hash: `#${ROOTSECTION.contact}`,
   },
 ];
 

--- a/src/pages/root/layout.tsx
+++ b/src/pages/root/layout.tsx
@@ -4,6 +4,7 @@ import { Outlet } from 'react-router-dom';
 import { Footer } from '@/components/footer';
 import { Header } from '@/components/header';
 import { AnalyticsService } from '@/lib/services/analytics';
+import HashProvider from '@/providers/hash-provider';
 import ToasterProvider from '@/providers/toaster-provider';
 import { AppRoutes } from '@/routes/app-routes';
 
@@ -18,11 +19,13 @@ const RootLayout = () => {
 
   return (
     <ToasterProvider>
-      <Header />
-      <main className='h-full max-w-screen-lg mx-auto max-xl:overflow-x-hidden'>
-        <Outlet />
-      </main>
-      <Footer />
+      <HashProvider>
+        <Header />
+        <main className='h-full max-w-screen-lg mx-auto max-xl:overflow-x-hidden'>
+          <Outlet />
+        </main>
+        <Footer />
+      </HashProvider>
     </ToasterProvider>
   );
 };

--- a/src/providers/hash-provider.tsx
+++ b/src/providers/hash-provider.tsx
@@ -1,0 +1,32 @@
+import { useLenis } from 'lenis/react';
+import { ReactNode, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+interface HashProviderProps {
+  children: ReactNode;
+}
+
+function HashProvider({ children }: HashProviderProps) {
+  const { hash } = useLocation();
+  const lenis = useLenis();
+
+  useEffect(() => {
+    if (!hash || !lenis) return;
+
+    // remove "#" from the hash
+    const id = hash.substring(1);
+    const section = document.getElementById(id);
+
+    if (!section) return;
+
+    // When changing a route, the DOM tree changes height,
+    // but its not aware of the change, so we need to resize it before scrolling
+    lenis.resize();
+
+    lenis.scrollTo(section);
+  }, [hash, lenis]);
+
+  return <>{children}</>;
+}
+
+export default HashProvider;


### PR DESCRIPTION
- Made header navigation menus persist and remain visible when switching routes.
- Added logic to handle section hash navigation:
  - If a navigation link with a hash is clicked outside the root page, redirect to the root and scroll to the section.
- Introduced a provider to handle Lenis resize events.
- Ensured smooth scrolling to the targeted section after navigation.

This enhances UX by ensuring consistent navigation behavior and better handling of hash-based section scrolling.