### PR TITLE
chore: disable analytics when running in development mode

### DIFF
--- a/src/pages/error/page.tsx
+++ b/src/pages/error/page.tsx
@@ -7,6 +7,8 @@ import { AppRoutes } from '@/routes/app-routes';
 
 const ErrorPage = () => {
   useEffect(() => {
+    if (import.meta.env.DEV) return;
+
     // Intentionally ignore the returned promise.
     void AnalyticsService.pageView({
       location: AppRoutes.github404,

--- a/src/pages/not-found/page.tsx
+++ b/src/pages/not-found/page.tsx
@@ -7,6 +7,8 @@ import { AppRoutes } from '@/routes/app-routes';
 
 const NotFoundPage = () => {
   useEffect(() => {
+    if (import.meta.env.DEV) return;
+
     // Intentionally ignore the returned promise.
     void AnalyticsService.pageView({
       location: AppRoutes.notFound,

--- a/src/pages/root/layout.tsx
+++ b/src/pages/root/layout.tsx
@@ -10,6 +10,8 @@ import { AppRoutes } from '@/routes/app-routes';
 
 const RootLayout = () => {
   useEffect(() => {
+    if (import.meta.env.DEV) return;
+
     // Intentionally ignore the returned promise.
     void AnalyticsService.pageView({
       location: AppRoutes.root,

--- a/src/pages/skills/page.tsx
+++ b/src/pages/skills/page.tsx
@@ -13,6 +13,8 @@ const SkillsPage = () => {
   const { onActive } = useRootSectionStore();
 
   useEffect(() => {
+    if (import.meta.env.DEV) return;
+
     // Intentionally ignore the returned promise.
     void AnalyticsService.pageView({
       location: AppRoutes.skills,


### PR DESCRIPTION
- Added guard to prevent analytics from initializing in dev mode.
- Ensures tracking only occurs in staging/production environments.
- Prevents pollution of real analytics data from local development.

This change keeps the dev environment clean while maintaining accurate analytics data collection in higher environments.