### PR TITLE
fix: resolve responsive style issues for icons and text below 1024px breakpoint

### DIFF
--- a/src/components/common/skill-icon.tsx
+++ b/src/components/common/skill-icon.tsx
@@ -25,7 +25,7 @@ const SkillIcon = ({ Icon, hexColor, ariaHidden }: SkillIconProps) => {
     >
       <Icon
         color={hovered ? hexColor : undefined}
-        className={cn('w-6 lg:w-12 h-6 lg:h-12', !hovered && 'opacity-50')}
+        className={cn('size-6 md:size-12', !hovered && 'opacity-50')}
       />
     </li>
   );

--- a/src/pages/root/_components/skills/index.tsx
+++ b/src/pages/root/_components/skills/index.tsx
@@ -37,13 +37,13 @@ const Skills = () => {
       )}
     >
       <div className='leading-none flex-center flex-col'>
-        <h4 className='text-xs lg:text-sm font-bold text-center tracking-widest pt-6 lg:pb-2'>
+        <h4 className='text-xs sm:text-sm font-bold text-center tracking-widest pt-6 sm:pb-2'>
           SKILLS
         </h4>
-        <p className='text-xl lg:text-5xl text-center'>
+        <p className='text-xl sm:text-5xl text-center'>
           Innovate, Implement, <span className='text-primary'>Repeat.</span>
         </p>
-        <p className='text-xs lg:text-sm text-muted-foreground text-center lg:mt-2 w-3/4 lg:w-full'>
+        <p className='text-xs sm:text-sm text-muted-foreground text-center sm:mt-2 w-3/4 sm:w-full'>
           Showcasing the skills I've developed and refined over the past 3
           years.
         </p>


### PR DESCRIPTION
- Applied consistent styling for skill icons at medium screen sizes (≤1024px).
- Ensured text styles remain uniform across small screens and above.
- Fixes layout inconsistencies where icons and text used mismatched styles in responsive views.

This improves UI consistency and readability across breakpoints.