### PR TITLE
refactor: display 6 random items in projects section and add dedicated page

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,37 @@
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
+/**
+ * Merges multiple class name values into a single string, handling conditional and array values,
+ * and resolving Tailwind CSS class conflicts.
+ *
+ * @param inputs - A list of class values (strings, arrays, or objects) to be merged.
+ * @returns A single string with merged and deduplicated class names.
+ *
+ * @example
+ * ```ts
+ * cn('btn', { 'btn-active': isActive }, ['extra-class']);
+ * // => "btn btn-active extra-class" (if isActive is true)
+ * ```
+ */
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
+}
+
+/**
+ * Returns a new array with the elements of the input array shuffled in random order.
+ * The original array is not mutated.
+ *
+ * @typeParam T - The type of elements in the array.
+ * @param array - The array to shuffle.
+ * @returns A new array with the elements shuffled.
+ */
+export function shuffleArray<T>(array: T[]): T[] {
+  const arr = array.slice(); // clone the array to not mutate the original
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i - 1)); // random index from 0 to i
+    [arr[i], arr[j]] = [arr[j], arr[i]]; // swap
+  }
+
+  return arr;
 }

--- a/src/pages/projects/page.tsx
+++ b/src/pages/projects/page.tsx
@@ -1,0 +1,9 @@
+const ProjectsPage = () => {
+  return (
+    <section className='min-h-[calc(100dvh_-_56px)] space-y-2 lg:space-y-12 p-6 lg:py-6 lg:px-4 xl:px-0 mt-14'>
+      Projects Page
+    </section>
+  );
+};
+
+export { ProjectsPage };

--- a/src/pages/root/_components/projects/index.tsx
+++ b/src/pages/root/_components/projects/index.tsx
@@ -1,16 +1,39 @@
+import { useLenis } from 'lenis/react';
 import { Terminal } from 'lucide-react';
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
+import { Link } from 'react-router-dom';
 
 import { QUERYELEMENT, ROOTSECTION } from '@/constants/enums';
 import { PROJECTS } from '@/constants/projects';
 import { useObserver } from '@/lib/hooks/useObserver';
-import { cn } from '@/lib/utils';
+import { useRootSectionStore } from '@/lib/stores/useRootSectionStore';
+import { cn, shuffleArray } from '@/lib/utils';
+import { AppRoutes } from '@/routes/app-routes';
 
 import { ProjectItem, ProjectItemSkeleton } from './project-item';
 
 const Projects = () => {
   const sectionRef = useRef<HTMLElement | null>(null);
   const { isVisible } = useObserver({ elementRef: sectionRef });
+  const lenis = useLenis();
+  const { onActive } = useRootSectionStore();
+  const projectsRef = useRef<typeof PROJECTS>(null);
+
+  useEffect(() => {
+    const projects = projectsRef.current;
+
+    if (projects !== null) return;
+
+    const shuffledProjects = shuffleArray(PROJECTS);
+    projectsRef.current = shuffledProjects;
+  }, []);
+
+  const handleScroll = () => {
+    if (!lenis) return;
+
+    onActive(ROOTSECTION.projects);
+    lenis.scrollTo(0);
+  };
 
   return (
     <section
@@ -27,10 +50,20 @@ const Projects = () => {
         <span className='w-[32px] lg:w-[128px] h-1 rounded-full bg-muted-foreground tracking-widest' />
       </div>
 
-      <p className='text-xs lg:text-sm text-muted-foreground text-center lg:mt-2 w-3/4 lg:w-full'>
-        I’ve developed various projects, ranging from web applications to
-        Android apps. Here are a few highlights.
-      </p>
+      <div className='flex-center flex-col gap-y-1'>
+        <p className='text-xs lg:text-sm text-muted-foreground text-center lg:mt-2 w-3/4 lg:w-full'>
+          I’ve developed various projects, ranging from web applications to
+          Android apps. Here are a few highlights.
+        </p>
+
+        <Link
+          to={AppRoutes.projects}
+          onClick={handleScroll}
+          className='mt-2 text-sm hover:text-accent hover:drop-shadow-purple-glow underline-offset-4 hover:underline'
+        >
+          View All
+        </Link>
+      </div>
 
       <div
         style={{
@@ -42,15 +75,15 @@ const Projects = () => {
           isVisible ? 'opacity-100' : 'opacity-0',
         )}
       >
-        {isVisible ? (
+        {isVisible && projectsRef.current ? (
           <>
-            {PROJECTS.map((p) => (
+            {projectsRef.current.slice(0, 6).map((p) => (
               <ProjectItem key={p.name} {...p} />
             ))}
           </>
         ) : (
           <>
-            {[...Array(8)].map((_, i) => (
+            {[...Array(6)].map((_, i) => (
               <ProjectItemSkeleton key={`project-item-skeleton-${i}`} />
             ))}
           </>

--- a/src/routes/app-routes.ts
+++ b/src/routes/app-routes.ts
@@ -3,4 +3,5 @@ export const enum AppRoutes {
   notFound = '*',
   github404 = '/404',
   skills = '/skills',
+  projects = '/projects',
 }

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -6,6 +6,7 @@ import {
 
 import ErrorPage from '@/pages/error/page';
 import NotFoundPage from '@/pages/not-found/page';
+import { ProjectsPage } from '@/pages/projects/page';
 import RootLayout from '@/pages/root/layout';
 import RootPage from '@/pages/root/page';
 import { SkillsPage } from '@/pages/skills/page';
@@ -24,6 +25,9 @@ export const router = createBrowserRouter(
 
       {/* Skills */}
       <Route path={AppRoutes.skills} element={<SkillsPage />} />
+
+      {/* Projects */}
+      <Route path={AppRoutes.projects} element={<ProjectsPage />} />
 
       {/* Github 404 */}
       <Route path={AppRoutes.github404} element={<NotFoundPage />} />


### PR DESCRIPTION
Refactor the Projects section to improve performance and user experience:

- Limit the homepage Projects section to display 6 items at a time, chosen randomly.
- Implement a Fisher-Yates shuffle to ensure a uniform random selection of projects.
- Add a dedicated Projects page to view all projects.
- Add a "View All" link on the homepage Projects section pointing to the new Projects page.
- Ensure styling and layout remain consistent across homepage and projects page.

This change provides a cleaner homepage view while giving users access to the full projects list on demand.