### PR TITLE
chore: refine frontend and backend PR check triggers

### DIFF
--- a/.github/workflows/backend-pr-checks.yaml
+++ b/.github/workflows/backend-pr-checks.yaml
@@ -6,15 +6,7 @@ on:
       - main
     paths:
       - '.github/workflows/backend-pr-checks.yaml'
-      - 'cmd/**'
-      - 'go.mod'
-      - 'go.sum'
-      - 'internal/**'
-      - 'pkg/**'
-      - 'scripts/**'
-      - '.env.**'
-      - '**.md'
-      - '.gitignore'
+      - 'backend/**'
 
 permissions:
   contents: read

--- a/.github/workflows/frontend-pr-checks.yaml
+++ b/.github/workflows/frontend-pr-checks.yaml
@@ -4,22 +4,8 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - '.github/workflows/frontend-pr-checks.yaml'
-      - 'src/**'
-      - 'public/**'
-      - '.env.**'
-      - '.gitignore'
-      - '**.md'
-      - '.prettier**'
-      - 'components.json'
-      - 'eslint.config.js'
-      - 'index.html'
-      - 'package**.json'
-      - 'tailwind.config.js'
-      - 'tsconfig.**'
-      - 'vite.config.ts'
     paths-ignore:
+      - '.github/workflows/backend-pr-checks.yaml'
       - 'backend/**'
       - 'admin/**'
 

--- a/.github/workflows/frontend-pr-checks.yaml
+++ b/.github/workflows/frontend-pr-checks.yaml
@@ -9,9 +9,19 @@ on:
       - 'src/**'
       - 'public/**'
       - '.env.**'
-      - '**.md'
       - '.gitignore'
-    types: [opened, edited, synchronize, reopened]
+      - '**.md'
+      - '.prettier**'
+      - 'components.json'
+      - 'eslint.config.js'
+      - 'index.html'
+      - 'package**.json'
+      - 'tailwind.config.js'
+      - 'tsconfig.**'
+      - 'vite.config.ts'
+    paths-ignore:
+      - 'backend/**'
+      - 'admin/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
Refines GitHub Actions workflow triggers so that frontend and backend PR checks only run when their respective files are modified.

- **Backend PR Quality Checks**
  - Simplified to trigger on `backend/**` (covers code, configs, envs, docs).
- **Frontend PR Quality Checks**
  - Limited to frontend-related files (`src/**`, `public/**`, configs, envs, docs).
  - Added `paths-ignore: backend/**` to prevent running on backend-only changes.

Previously, both workflows were too broad:
- Frontend checks were triggered by backend-only changes.
- Backend checks were triggered by frontend/global changes.

This update ensures:
- Backend checks run **only** for backend changes.
- Frontend checks run **only** for frontend changes.
- Fewer unnecessary CI jobs, clearer workflow separation.

- Faster, more efficient CI.
- Reduced noise in PR quality checks.
- Better alignment of checks with code ownership boundaries.