### PR TITLE
chore: enable Dependabot PR updates for admin path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,21 @@ updates:
   - package-ecosystem: 'npm'
     directory: /
     schedule:
-      interval: 'daily' # Check for updates every day
+      interval: 'daily'
     commit-message:
-      prefix: 'chore' # Use 'chore' prefix for the commit message
-      include: 'scope' # Include the scope (dependency name) in the commit message
+      prefix: 'chore'
+      include: 'scope'
     open-pull-requests-limit: 10
-    reviewers:
-      - fingertips18
+
+  # Update npm dependencies in the admin directory
+  - package-ecosystem: 'npm'
+    directory: /admin
+    schedule:
+      interval: 'daily'
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+    open-pull-requests-limit: 10
 
   # Update go dependencies in the backend directory
   - package-ecosystem: 'gomod'
@@ -21,8 +29,6 @@ updates:
       prefix: 'chore'
       include: 'scope'
     open-pull-requests-limit: 10
-    reviewers:
-      - fingertips18
 
   # Update github actions dependencies in the root directory
   - package-ecosystem: 'github-actions'
@@ -32,6 +38,3 @@ updates:
     commit-message:
       prefix: 'chore'
       include: 'scope'
-    open-pull-requests-limit: 10
-    reviewers:
-      - fingertips18


### PR DESCRIPTION
- Added Dependabot configuration to automatically check and open PRs for dependency updates in the `/admin` directory
- Ensures admin dependencies stay up to date with security and compatibility patches
- Removed the reviewers; not needed since we already have CODEOWNERS in place

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized Dependabot commit messages to use a “chore” prefix with scopes for clearer history.
  * Capped simultaneous dependency PRs to 10 for npm projects to reduce noise.
  * Switched GitHub Actions dependency updates to a weekly schedule to smooth PR flow.
  * Removed automatic reviewer assignments from dependency PRs to streamline triage.
  * Applied configurations across root and admin npm packages; cleaned up settings for Go modules while keeping existing schedules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->