### PR TITLE
feat: add update skill handler, route, tests, and swagger docs

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -695,6 +695,61 @@ const docTemplate = `{
             }
         },
         "/skill": {
+            "put": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Updates an existing skill using the ID provided in the request body. Returns the updated skill.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skill"
+                ],
+                "summary": "Update a skill",
+                "parameters": [
+                    {
+                        "description": "Skill payload with ID",
+                        "name": "skill",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v1.UpdateSkillRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v1.UpdateSkillResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/v1.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/v1.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/v1.ErrorResponse"
+                        }
+                    }
+                }
+            },
             "post": {
                 "security": [
                     {
@@ -1098,6 +1153,52 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/v1.SchoolPeriodDTO"
                     }
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "v1.UpdateSkillRequest": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "hex_color": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                }
+            }
+        },
+        "v1.UpdateSkillResponse": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "hex_color": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
                 },
                 "updated_at": {
                     "type": "string"

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -687,6 +687,61 @@
             }
         },
         "/skill": {
+            "put": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Updates an existing skill using the ID provided in the request body. Returns the updated skill.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skill"
+                ],
+                "summary": "Update a skill",
+                "parameters": [
+                    {
+                        "description": "Skill payload with ID",
+                        "name": "skill",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v1.UpdateSkillRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v1.UpdateSkillResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/v1.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/v1.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/v1.ErrorResponse"
+                        }
+                    }
+                }
+            },
             "post": {
                 "security": [
                     {
@@ -1090,6 +1145,52 @@
                     "items": {
                         "$ref": "#/definitions/v1.SchoolPeriodDTO"
                     }
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "v1.UpdateSkillRequest": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "hex_color": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                }
+            }
+        },
+        "v1.UpdateSkillResponse": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "hex_color": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
                 },
                 "updated_at": {
                     "type": "string"

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -197,6 +197,36 @@ definitions:
       updated_at:
         type: string
     type: object
+  v1.UpdateSkillRequest:
+    properties:
+      category:
+        type: string
+      hex_color:
+        type: string
+      icon:
+        type: string
+      id:
+        type: string
+      label:
+        type: string
+    type: object
+  v1.UpdateSkillResponse:
+    properties:
+      category:
+        type: string
+      created_at:
+        type: string
+      hex_color:
+        type: string
+      icon:
+        type: string
+      id:
+        type: string
+      label:
+        type: string
+      updated_at:
+        type: string
+    type: object
 info:
   contact: {}
   description: This API powers the portfolio platform, offering endpoints to manage
@@ -678,6 +708,42 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Create a skill
+      tags:
+      - skill
+    put:
+      consumes:
+      - application/json
+      description: Updates an existing skill using the ID provided in the request
+        body. Returns the updated skill.
+      parameters:
+      - description: Skill payload with ID
+        in: body
+        name: skill
+        required: true
+        schema:
+          $ref: '#/definitions/v1.UpdateSkillRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v1.UpdateSkillResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/v1.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/v1.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/v1.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Update a skill
       tags:
       - skill
   /skill/{id}:

--- a/backend/internal/handler/v1/dto.go
+++ b/backend/internal/handler/v1/dto.go
@@ -94,6 +94,24 @@ type CreateSkillRequest struct {
 	Category string `json:"category"`
 }
 
+type UpdateSkillRequest struct {
+	Id       string `json:"id"`
+	Icon     string `json:"icon"`
+	HexColor string `json:"hex_color"`
+	Label    string `json:"label"`
+	Category string `json:"category"`
+}
+
+type UpdateSkillResponse struct {
+	Id        string    `json:"id"`
+	Icon      string    `json:"icon"`
+	HexColor  string    `json:"hex_color"`
+	Label     string    `json:"label"`
+	Category  string    `json:"category"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
 type SkillDTO struct {
 	Id        string    `json:"id"`
 	Icon      string    `json:"icon"`


### PR DESCRIPTION
Implemented UpdateSkill handler and integrated it into the routing layer.

Changes:
- Added UpdateSkill handler for modifying existing skill records.
- Registered PUT /skills/:id route.
- Added comprehensive unit tests covering success, validation, and not-found cases.
- Updated Swagger annotations to include the update endpoint.
- Regenerated Swagger documentation to reflect the latest changes.

Ensures full CRUD support for skills and maintains API documentation accuracy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added PUT /skill endpoint to update existing skills
- Supports updating skill attributes with comprehensive validation and error handling

## Documentation
- Updated API reference with skill update endpoint specifications, including request/response schemas, security requirements, and error responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->