### PR TITLE
fix: only trigger unsaved changes when form is not submitted

### DIFF
--- a/apps/admin/src/pages/project/add/_components/form.tsx
+++ b/apps/admin/src/pages/project/add/_components/form.tsx
@@ -89,6 +89,7 @@ type Schema = z.infer<typeof formSchema>;
 export function Form() {
   const [imageLoading, setImageLoading] = useState<boolean>(false);
   const [projectLoading, setProjectLoading] = useState<boolean>(false);
+  const [submitted, setSubmitted] = useState<boolean>(false);
   const form = useForm<Schema>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -104,7 +105,9 @@ export function Form() {
   });
   const abortRef = useRef<AbortController | null>(null);
   const navigate = useNavigate();
-  useUnsavedChanges({ hasUnsavedChanges: form.formState.isDirty });
+  useUnsavedChanges({
+    hasUnsavedChanges: !submitted && form.formState.isDirty,
+  });
 
   useEffect(() => {
     abortRef.current = new AbortController();
@@ -179,6 +182,7 @@ export function Form() {
         description: `${values.title} uploaded successfully!`,
       });
 
+      setSubmitted(true);
       form.reset();
       void navigate(Route.project);
     } catch {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form submission handling to prevent unsaved changes warning from appearing after successfully submitting a project. The form now properly tracks submission state to ensure users can navigate away without unnecessary warnings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->