### PR TITLE
fix: explicitly define go version in backend pr checks

### DIFF
--- a/.github/workflows/backend-pr-checks.yaml
+++ b/.github/workflows/backend-pr-checks.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.x"
+          go-version: "1.25.5"
           cache-dependency-path: go.sum
 
       - name: Check Go version
@@ -97,7 +97,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.x"
+          go-version: "1.25.5"
 
       - name: Download dependencies
         run: go mod download
@@ -119,7 +119,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ["1.25.x"]
+        go-version: ["1.25.5"]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version pinning in the continuous integration pipeline to ensure consistent builds across all jobs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->